### PR TITLE
Update array-unique version

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "arr-diff": "^2.0.0",
-    "array-unique": "^0.2.1",
+    "array-unique": "^0.3.2",
     "braces": "^1.8.2",
     "expand-brackets": "^0.1.4",
     "extglob": "^0.3.1",


### PR DESCRIPTION
in jonschlinkert/array-unique#5, i identified an issue with the file permissions in the array-unique 0.2.1 tarball.

since the problem doesn’t exist in array-unique 0.3.2, updating micromatch’s dependency will circumvent that issue.