### PR TITLE
Bug fix for #96 (.not returning incorrect results on windows)

### DIFF
--- a/index.js
+++ b/index.js
@@ -344,7 +344,8 @@ micromatch.not = function(list, patterns, options) {
   var ignore = opts.ignore;
   delete opts.ignore;
 
-  list = utils.arrayify(list);
+  var unixify = utils.unixify(opts);
+  list = utils.arrayify(list).map(unixify);
 
   var matches = utils.diff(list, micromatch(list, patterns, opts));
   if (ignore) {

--- a/test/support/match.js
+++ b/test/support/match.js
@@ -73,6 +73,16 @@ module.exports.create = function() {
   return matcher.create.apply(null, arguments);
 };
 
-module.exports.not = function() {
-  return matcher.not.apply(null, arguments);
+module.exports.not = function(fixtures, patterns, expected, options) {
+  if (!Array.isArray(expected)) {
+    var tmp = expected;
+    expected = options;
+    options = tmp;
+  }
+
+  var actual = matcher.not(fixtures, patterns, options);
+  expected.sort(compare);
+  actual.sort(compare);
+
+  assert.deepEqual(actual, expected, patterns);
 };


### PR DESCRIPTION
### Bug Fix

- [x] All existing unit tests are still passing (if applicable)
- [x] Add new passing unit tests to cover the code introduced by your pr
- [ ] Update the readme (see [readme advice](#readme-advice))
- [ ] Update or add any necessary API documentation
- [ ] Add your info to the [contributors](#packagejson-contributors) array in package.json!

### Description

Currently, the matches returned from `micromatch` inside the `.not` method are removed from the `list` array (which is the original list of files passed into `micromatch.not`.

This PR uses `utils.unixify` on the `list` array to ensure that the original files are unixified (if specified in the options) so when "diffing" the correct file paths will be remove and returned.

### Updates made

 - update `.not` method in the test support matcher
 - unixify the `list` of files passed into `micromatch.not`
 - closes #96 

