### PR TITLE
ISSUE-116: Broken RegExp for pattern with noext option

### DIFF
--- a/lib/compilers.js
+++ b/lib/compilers.js
@@ -50,7 +50,7 @@ function escapeExtglobs(compiler) {
   compiler.set('paren', function(node) {
     var val = '';
     visit(node, function(tok) {
-      if (tok.val) val += '\\' + tok.val;
+      if (tok.val) val += (/^\W/.test(tok.val) ? '\\' : '') + tok.val;
     });
     return this.emit(val, node);
   });

--- a/test/options.js
+++ b/test/options.js
@@ -125,6 +125,10 @@ describe('options', function() {
   });
 
   describe('options.noext', function() {
+    it('should match when noext is true (issue #116)', function() {
+      assert(mm.isMatch('a/(dir)', 'a/(dir)', {noext: true}));
+    });
+
     it('should not match extglobs when noext is true', function() {
       assert(!mm.isMatch('ax', '?(a*|b)', {noext: true}));
       mm(['a.js.js', 'a.md.js'], '*.*(js).js', [], {noext: true});


### PR DESCRIPTION
#### Links

  * https://github.com/micromatch/micromatch/issues/116
  * https://github.com/sindresorhus/globby/issues/74

#### What is?

When we work with the `text` node – we shouldn't add a backward slash before it.

For example, the following pattern:

```
./test(dir)/foo.txt
```

Before fix:

```
/^(?:(?:(?:\.(?:\/|\\))(?=.))?test\(\dir\)\/foo\.txt)$/
```

After fix:

```diff
-/^(?:(?:(?:\.(?:\/|\\))(?=.))?test\(\dir\)\/foo\.txt)$/
+/^(?:(?:(?:\.(?:\/|\\))(?=.))?test\(dir\)\/foo\.txt)$/
```

#### Questions

  * Sorry but I don't understand where I should add the new test 😭 