### PR TITLE
FG-85: Bump snapdragon version to 0.11.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "nanomatch": "^1.2.9",
     "object.pick": "^1.3.0",
     "regex-not": "^1.0.0",
-    "snapdragon": "^0.8.1",
+    "snapdragon": "^0.11.2",
     "to-regex": "^3.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
> ⚠️ WIP

### Why?

This is fix for https://github.com/mrmlnc/fast-glob/issues/85.

### How it works?

The new version of the «snapdragon» package uses the new version of the «use» package which solves some of the problems of using the «mock-fs» package.

### Bug Fix

- [ ] All existing unit tests are still passing (if applicable)
- [ ] ~~Add new passing unit tests to cover the code introduced by your pr~~
- [ ] ~~Update the readme (see [readme advice](#readme-advice))~~
- [ ] ~~Update or add any necessary API documentation~~
- [ ] ~~Add your info to the [contributors](#packagejson-contributors) array in package.json!~~