### PR TITLE
fix nanomatch version because of breaking change in v1.2.9+

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "extglob": "^2.0.4",
     "fragment-cache": "^0.2.1",
     "kind-of": "^6.0.2",
-    "nanomatch": "^1.2.9",
+    "nanomatch": "1.2.9",
     "object.pick": "^1.3.0",
     "regex-not": "^1.0.0",
     "snapdragon": "^0.8.1",


### PR DESCRIPTION
Temporary fix for micromatch being affected by [nanomatch issue #15](https://github.com/micromatch/nanomatch/issues/15)