### PR TITLE
feat: add replaceSeparatorsForGlob utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,6 +581,16 @@ Clear the regex cache.
 mm.clearCache();
 ```
 
+### [.replaceSeparatorsForGlob](index.js#L871)
+
+Replaces backslashes used as path separators with forward slashes. This is useful on Windows when using `path.join` et.al. See [Backslashes](#backslashes).
+
+**Example**
+
+```js
+var reaplcedPath = mm.replaceSeparatorsForGlob(path.join(rootDir, 'other/path/**'));
+```
+
 ## Options
 
 * [basename](#optionsbasename)
@@ -944,6 +954,8 @@ We made this decision for micromatch for a couple of reasons:
 
 * consistency with bash conventions.
 * glob patterns are not filepaths. They are a type of [regular language](https://en.wikipedia.org/wiki/Regular_language) that is converted to a JavaScript regular expression. Thus, when forward slashes are defined in a glob pattern, the resulting regular expression will match windows or POSIX path separators just fine.
+
+You can use `.replaceSeparatorsForGlob` to replace backslashes used as path separators.
 
 **A note about joining paths to globs**
 

--- a/index.js
+++ b/index.js
@@ -870,6 +870,19 @@ micromatch.parsers = parsers;
 micromatch.caches = cache.caches;
 
 /**
+ * Replace backslashes used as path separator with forward slashes.
+ * This is useful when doing `path.resolve` etc. in Windows.
+ */
+
+micromatch.replaceSeparatorsForGlob = function(path) {
+  if (typeof path !== 'string') {
+    throw new TypeError('expected a string: "' + util.inspect(path) + '"');
+  }
+
+  return path.replace(/\\(?![{}()+?.^$])/g, '/');
+};
+
+/**
  * Expose `micromatch`
  * @type {Function}
  */

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "Tom Byrer (https://github.com/tomByrer)",
     "Tyler Akins (http://rumkin.com)",
     "(https://github.com/DianeLooney)",
-    "Tvrqvoise (https://github.com/tvrqvoise)"
+    "Tvrqvoise (https://github.com/tvrqvoise)",
+    "Simen Bekkhus (https://github.com/SimenB)"
   ],
   "repository": "micromatch/micromatch",
   "bugs": {

--- a/test/api.replaceSeparatorsForGlob.js
+++ b/test/api.replaceSeparatorsForGlob.js
@@ -1,0 +1,20 @@
+'use strict';
+
+var assert = require('assert');
+var mm = require('..');
+
+describe('.replaceSeparatorsForGlob()', function() {
+  it('should throw an error when value is not a string', function() {
+    assert.throws(function() {
+      mm.replaceSeparatorsForGlob();
+    });
+  });
+
+  it('should replace backslashes', function() {
+    assert.equal(mm.replaceSeparatorsForGlob('/some/path\\with\\backslashes'), '/some/path/with/backslashes');
+  });
+
+  it('should not replace backslashes when they are escaped characters', function() {
+    assert.equal(mm.replaceSeparatorsForGlob('/some/path\\with\\backslashes/and\\(parens\\)'), '/some/path/with/backslashes/and\\(parens\\)');
+  });
+});


### PR DESCRIPTION
## Description

We've had some issues in Jest with paths using mixed path separators due to both running on windows and some incomplete normalization. So we've added a utility which we use everywhere we use `micromatch`

See https://github.com/facebook/jest/pull/6650 where this regex comes from. (if you have any feedback on that PR, it'd be most welcome btw 😀)

Note that we should probably be better at normalization in Jest as well as use `path.posix.join` etc to avoid the backslashes. But it doesn't always make sense (and doesn't necessarily always work) to use forward slashes, especially when doing FS operation, so being able to just pass things through a helper for `multimatch` is simpler.

## Checklist

- [ ] If this is a big feature with breaking changes, consider [opening an issue][issues] to discuss first. This is completely up to you, but please keep in mind that your pr might not be accepted.
- [x] Run unit tests to ensure all existing tests are still passing
- [x] Add new passing unit tests to cover the code introduced by your pr
- [x] Update the readme (see [readme advice](#readme-advice))
- [x] Add your info to the [contributors](#packagejson-contributors) array in package.json!