### PR TITLE
re-add .any method as alias to .isMatch

### DIFF
--- a/index.js
+++ b/index.js
@@ -123,6 +123,12 @@ micromatch.matcher = (pattern, options) => picomatch(pattern, options);
 micromatch.isMatch = (str, patterns, options) => picomatch(patterns, options)(str);
 
 /**
+ * Backwards compatibility
+ */
+
+micromatch.any = micromatch.isMatch;
+
+/**
  * Returns a list of strings that _**do not match any**_ of the given `patterns`.
  *
  * ```js

--- a/test/api.isMatch.js
+++ b/test/api.isMatch.js
@@ -1,12 +1,18 @@
 'use strict';
 
 const assert = require('assert');
-const { isMatch } = require('..');
+const { isMatch, any } = require('..');
 
 describe('.isMatch():', () => {
   describe('error handling:', () => {
     it('should throw on bad args', () => {
       assert.throws(() => isMatch({}), /Expected/i);
+    });
+  });
+
+  describe('alias:', () => {
+    it('should have the alias .any(...)', () => {
+      assert.strictEqual(isMatch, any);
     });
   });
 


### PR DESCRIPTION
Alias `.any()` to `.isMatch()` for backwards compatibility support. As discussed in #153.