### PR TITLE
Add test for #155

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "name": "micromatch",
   "description": "Glob matching for javascript/node.js. A replacement and faster alternative to minimatch and multimatch.",
   "version": "4.0.1",
@@ -17,7 +17,8 @@
     "Olsten Larck (https://i.am.charlike.online)",
     "Paul Miller (paulmillr.com)",
     "Tom Byrer (https://github.com/tomByrer)",
-    "Tyler Akins (http://rumkin.com)"
+    "Tyler Akins (http://rumkin.com)",
+    "Peter Bright <drpizza@quiscalusmexicanus.org> (https://github.com/drpizza)"
   ],
   "repository": "micromatch/micromatch",
   "bugs": {

--- a/test/api.capture.js
+++ b/test/api.capture.js
@@ -24,6 +24,7 @@ describe('.capture()', () => {
     assert.deepEqual(capture('test/**/*.js', 'test/a.js'), ['', 'a']);
     assert.deepEqual(capture('test/**/*.js', 'test/dir/a.js'), ['dir', 'a']);
     assert.deepEqual(capture('test/**/*.js', 'test/dir/test/a.js'), ['dir/test', 'a']);
+    assert.deepEqual(capture('**/*.js', 'test/dir/a.js'), ['test/dir', 'a']);
   });
 
   it('should capture extglobs', () => {


### PR DESCRIPTION
Adds a test for #155. The specific error condition appears to arise when the globstar matches against the full path rather than a portion of it; this for whatever reason upsets all captures except the globstar.