### PR TITLE
Remove superfluous contributor section directions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,6 @@ There are three main goals in this document, depending on the nature of your pr:
 
 - [description](#description): please tell us about your pr
 - [checklist](#checklist): please review the checklist that is most closly related to your pr
-- [contributors list](#packagejson-contributors): you're one of us now, please add yourself to `package.json` and let the world know!
 
 The following sections provide more detail on each.
 
@@ -34,12 +33,10 @@ Please use the checklist that is most closely related to your pr _(you only need
 ### Fixing typos
 
 - [ ] Please review the [readme advice]() section before submitting changes
-- [ ] Add your to the [contributors](#packagejson-contributors) array in package.json!
 
 ### Documentation
 
 - [ ] Please review the [readme advice](#readme-advice) section before submitting changes
-- [ ] Add your info to the [contributors](#packagejson-contributors) array in package.json!
 
 ### Bug Fix
 
@@ -47,7 +44,6 @@ Please use the checklist that is most closely related to your pr _(you only need
 - [ ] Add new passing unit tests to cover the code introduced by your pr
 - [ ] Update the readme (see [readme advice](#readme-advice))
 - [ ] Update or add any necessary API documentation
-- [ ] Add your info to the [contributors](#packagejson-contributors) array in package.json!
 
 ### New Feature
 
@@ -55,7 +51,6 @@ Please use the checklist that is most closely related to your pr _(you only need
 - [ ] Run unit tests to ensure all existing tests are still passing
 - [ ] Add new passing unit tests to cover the code introduced by your pr
 - [ ] Update the readme (see [readme advice](#readme-advice))
-- [ ] Add your info to the [contributors](#packagejson-contributors) array in package.json!
 
 Thanks for contributing!
 
@@ -78,31 +73,6 @@ Please add code comments (following the same style as existing comments) to desc
 Any changes made `.verb.md` and/or code comments will be automatically incorporated into the README documentation the next time `verb` is run.
 
 We can take care of building the documentation for you when we merge in your changes, or feel free to run [verb][] yourself. Whatever you prefer is fine with us.
-
-## package.json contributors
-
-**Add yourself!**
-
-When adding your information to the `contributors` array in package.json, please use the following format (provide your name at minimum, the other fields are optional):
-
-```
-full name <email@address.com> (https://website.com)
-```
-
-**Example**
-
-```json
-// -- package.json --
-{
-  "name": "micromatch",
-  "contributors": [
-    "Brian Woodward <jon.schlinkert@sellside.com> (https://github.com/jonschlinkert)",
-    "Jon Schlinkert <brian.woodward@sellside.com> (https://github.com/doowb)",
-  ]
-}
-```
-
-_(If a `contributors` array does not already exist, please feel free to add one wherever you want, and congratulations on being the first to contribute!)_
 
 [issues]: ../../issues
 [verb]: https://github.com/verbose/verb


### PR DESCRIPTION
Apparently being added to the contributors section is automatic.
