### PR TITLE
docs: Add Node.js 8 requirement to changelog breaking section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Changelog entries are classified using the following labels _(from [keep-a-chang
 
 ### Breaking changes
 
+- Require Node.js >= 8
 - Removed support for passing an array of brace patterns to `micromatch.braces()`.
 - To strictly enforce closing brackets (for `{`, `[`, and `(`), you must now use `strictBrackets=true` instead of `strictErrors`.   
 - `cache` - caching and all related options and methods have been removed
@@ -72,7 +73,7 @@ Here are those sub-modules with links to related prs on those modules if you wan
 
 **Added**
 
- - source map support (optionally created when using parse or compile - I have no idea what the use case is yet, but they come for free) (note that source maps are not generated for brace expansion at present, since the braces compiler uses a different strategy. I'll update if/when this changes). 
+ - source map support (optionally created when using parse or compile - I have no idea what the use case is yet, but they come for free) (note that source maps are not generated for brace expansion at present, since the braces compiler uses a different strategy. I'll update if/when this changes).
  - parser is exposed, so that implementors can customize or override specific micromatch parsers if necessary
  - compiler is exposed, so that implementors can customize or override specific micromatch compilers if necessary
 


### PR DESCRIPTION
Related to https://github.com/micromatch/micromatch/issues/160