### PR TITLE
docs(readme): fix relative link

### DIFF
--- a/.verb.md
+++ b/.verb.md
@@ -31,7 +31,7 @@ console.log(micromatch.isMatch('foo', ['b*', 'f*'])) //=> true
 - More complete support for the Bash 4.3 specification than minimatch and multimatch. Micromatch passes _all of the spec tests_ from bash, including some that bash still fails.
 - **Fast & Performant** - Loads in about 5ms and performs [fast matches](#benchmarks).
 - **Glob matching** - Using wildcards (`*` and `?`), globstars (`**`) for nested directories
-- **[Advanced globbing](#advanced-globbing)** - Supports [extglobs](#extglobs), [braces](#braces), and [POSIX brackets](#posix-bracket-expressions), and support for escaping special characters with `\` or quotes.
+- **[Advanced globbing](#extended-globbing)** - Supports [extglobs](#extglobs), [braces](#braces-1), and [POSIX brackets](#posix-bracket-expressions), and support for escaping special characters with `\` or quotes.
 - **Accurate** - Covers more scenarios [than minimatch](https://github.com/yarnpkg/yarn/pull/3339)
 - **Well tested** - More than 5,000 [test assertions](./test)
 - **Windows support** - More reliable windows support than minimatch and multimatch. 


### PR DESCRIPTION
## Description

Currently the readme has invalid relative links (link to a heading). "Advanced globbing" links to previous heading name. `braces` links to a code sample, instead of the actual description.

### Documentation

- [x] Please review the [readme advice](#readme-advice) section before submitting changes
