### PR TITLE
ISSUE-183: Refine required version of Node.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ Changelog entries are classified using the following labels _(from [keep-a-chang
 
 ### Breaking changes
 
-- Require Node.js >= 8
+- Require Node.js >= 8.6
 - Removed support for passing an array of brace patterns to `micromatch.braces()`.
 - To strictly enforce closing brackets (for `{`, `[`, and `(`), you must now use `strictBrackets=true` instead of `strictErrors`.
 - `cache` - caching and all related options and methods have been removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ Changelog entries are classified using the following labels _(from [keep-a-chang
 
 - Require Node.js >= 8
 - Removed support for passing an array of brace patterns to `micromatch.braces()`.
-- To strictly enforce closing brackets (for `{`, `[`, and `(`), you must now use `strictBrackets=true` instead of `strictErrors`.   
+- To strictly enforce closing brackets (for `{`, `[`, and `(`), you must now use `strictBrackets=true` instead of `strictErrors`.
 - `cache` - caching and all related options and methods have been removed
 - `options.unixify` was renamed to `options.windows`
 - `options.nodupes` Was removed. Duplicates are always removed by default. You can override this with custom behavior by using the `onMatch`, `onResult` and `onIgnore` functions.

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "main": "index.js",
   "engines": {
-    "node": ">=8"
+    "node": ">=8.6"
   },
   "scripts": {
     "test": "mocha"


### PR DESCRIPTION
This is a fix for #183.

### Documentation

- [x] Please review the [readme advice](#readme-advice) section before submitting changes

### Bug fixes

* The `micromatch` packages works only with Node.js 8.6+.