### PR TITLE
ISSUE-196: Require picomatch@2.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "braces": "^3.0.1",
-    "picomatch": "^2.0.5"
+    "picomatch": "^2.2.1"
   },
   "devDependencies": {
     "fill-range": "^7.0.1",


### PR DESCRIPTION
## Description

This is a fix for #196.

Looks like [yarn](https://github.com/yarnpkg/yarn) does not update transitive dependencies ([1](https://til.hashrocket.com/posts/unsfxg7dmw-force-upgrade-of-transitive-dependencies-in-yarn), [2](https://github.com/yarnpkg/yarn/issues/4986)). [Context](https://github.com/mrmlnc/fast-glob/issues/253#issuecomment-586677795).

I understand it looks like a [crutch/kludgy](https://russian.stackexchange.com/questions/14075/analog-of-it-term-%D0%BA%D0%BE%D1%81%D1%82%D1%8B%D0%BB%D1%8C-in-english), but… this looks correct, because in fact, this package should guarantee to work with all versions of `picomatch` starting from the specified one.