### PR TITLE
Fix: Put mm into bash mode for bash tests

### DIFF
--- a/test/bash.js
+++ b/test/bash.js
@@ -3,7 +3,9 @@
 require('mocha');
 const path = require('path');
 const assert = require('assert');
-const mm = require('..');
+const _mm = require('..');
+const mm = (l, p, o) => _mm(l, p, { ...o, bash: true });
+mm.isMatch = (l, p, o) => _mm.isMatch(l, p, { ...o, bash: true });
 
 const isWindows = () => process.platform === 'win32' || path.sep === '\\';
 const format = str => str.replace(/\\/g, '/').replace(/^\.\//, '');


### PR DESCRIPTION
It would appear that a section of the bash tests were being run without
micromatch being given the `bash` option.

Note: Supplying this option causes some of the tests to fail. In
particular, it would appear that in bash mode `*` will match into
directories like `**`, for example `*/c` will match `a/b/c`.