### PR TITLE
Add micromatch 3 to benchmark

### DIFF
--- a/bench/index.js
+++ b/bench/index.js
@@ -5,6 +5,7 @@ const { green } = require('ansi-colors');
 const argv = require('minimist')(process.argv.slice(2));
 const mm = require('minimatch');
 const mi = require('..');
+const mi3 = require('micromatch');
 
 /**
  * Setup
@@ -42,61 +43,73 @@ const bench = (name, options) => {
 };
 
 bench(green('.makeRe') + ' star')
-  .add('micromatch', () => mi.makeRe('*'))
+  .add('micromatch v4', () => mi.makeRe('*'))
+  .add('micromatch v3', () => mi3.makeRe('*'))
   .add('minimatch', () => mm.makeRe('*'))
   .run();
 
 bench(green('.makeRe') + ' star; dot=true')
-  .add('micromatch', () => mi.makeRe('*', { dot: true }))
+  .add('micromatch v4', () => mi.makeRe('*', { dot: true }))
+  .add('micromatch v3', () => mi3.makeRe('*', { dot: true }))
   .add('minimatch', () => mm.makeRe('*', { dot: true }))
   .run();
 
 bench(green('.makeRe') + ' globstar')
-  .add('micromatch', () => mi.makeRe('**'))
+  .add('micromatch v4', () => mi.makeRe('**'))
+  .add('micromatch v3', () => mi3.makeRe('**'))
   .add('minimatch', () => mm.makeRe('**'))
   .run();
 
 bench(green('.makeRe') + ' globstars')
-  .add('micromatch', () => mi.makeRe('**/**/**'))
+  .add('micromatch v4', () => mi.makeRe('**/**/**'))
+  .add('micromatch v3', () => mi3.makeRe('**/**/**'))
   .add('minimatch', () => mm.makeRe('**/**/**'))
   .run();
 
 bench(green('.makeRe') + ' with leading star')
-  .add('micromatch', () => mi.makeRe('*.txt'))
+  .add('micromatch v4', () => mi.makeRe('*.txt'))
+  .add('micromatch v3', () => mi3.makeRe('*.txt'))
   .add('minimatch', () => mm.makeRe('*.txt'))
   .run();
 
 bench(green('.makeRe') + ' - braces')
-  .add('micromatch', () => mi.makeRe('{a,b,c}*.txt'))
+  .add('micromatch v4', () => mi.makeRe('{a,b,c}*.txt'))
+  .add('micromatch v3', () => mi3.makeRe('{a,b,c}*.txt'))
   .add('minimatch', () => mm.makeRe('{a,b,c}*.txt'))
   .run();
 
 bench(green('.makeRe') + ' braces - range (expanded)')
-  .add('micromatch', () => mi.braces('foo/{1..250}/bar', { expand: true }))
+  .add('micromatch v4', () => mi.braces('foo/{1..250}/bar', { expand: true }))
+  .add('micromatch v3', () => mi3.braces('foo/{1..250}/bar', { expand: true }))
   .add('minimatch', () => mm.braceExpand('foo/{1..250}/bar'))
   .run();
 
 bench(green('.makeRe') + ' braces - range (compiled)')
-  .add('micromatch', () => mi.makeRe('foo/{1..250}/bar'))
+  .add('micromatch v4', () => mi.makeRe('foo/{1..250}/bar'))
+  .add('micromatch v3', () => mi3.makeRe('foo/{1..250}/bar'))
   .add('minimatch', () => mm.makeRe('foo/{1..250}/bar'))
   .run();
 
 bench(green('.makeRe') + ' braces - nested ranges (expanded)')
-  .add('micromatch', () => mi.braces('foo/{a,b,{1..250}}/bar', { expand: true }))
+  .add('micromatch v4', () => mi.braces('foo/{a,b,{1..250}}/bar', { expand: true }))
+  .add('micromatch v3', () => mi3.braces('foo/{a,b,{1..250}}/bar', { expand: true }))
   .add('minimatch', () => mm.braceExpand('foo/{a,b,{1..250}}/bar'))
   .run();
 
 bench(green('.makeRe') + ' braces - nested ranges (compiled)')
-  .add('micromatch', () => mi.makeRe('foo/{a,b,{1..250}}/bar'))
+  .add('micromatch v4', () => mi.makeRe('foo/{a,b,{1..250}}/bar'))
+  .add('micromatch v3', () => mi3.makeRe('foo/{a,b,{1..250}}/bar'))
   .add('minimatch', () => mm.makeRe('foo/{a,b,{1..250}}/bar'))
   .run();
 
 bench(green('.makeRe') + ' braces - set (compiled)')
-  .add('micromatch', () => mi.makeRe('foo/{a,b,c,d,e}/bar'))
+  .add('micromatch v4', () => mi.makeRe('foo/{a,b,c,d,e}/bar'))
+  .add('micromatch v3', () => mi3.makeRe('foo/{a,b,c,d,e}/bar'))
   .add('minimatch', () => mm.makeRe('foo/{a,b,c,d,e}/bar'))
   .run();
 
 bench(green('.makeRe') + ' braces - nested sets (compiled)')
-  .add('micromatch', () => mi.makeRe('foo/{a,b,c,d,e,{x,y,z}}/bar'))
+  .add('micromatch v4', () => mi.makeRe('foo/{a,b,c,d,e,{x,y,z}}/bar'))
+  .add('micromatch v3', () => mi3.makeRe('foo/{a,b,c,d,e,{x,y,z}}/bar'))
   .add('minimatch', () => mm.makeRe('foo/{a,b,c,d,e,{x,y,z}}/bar'))
   .run();

--- a/bench/package.json
+++ b/bench/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "ansi-colors": "^3.2.4",
     "benchmark": "^2.1.4",
+    "micromatch": "^3.1.10",
     "minimatch": "^3.0.4",
     "minimist": "^1.2.0"
   },


### PR DESCRIPTION
This is the result:

```sh
# .makeRe star
  micromatch v4 x 2,325,384 ops/sec ±1.67% (91 runs sampled)
  micromatch v3 x 15,767,622 ops/sec ±0.75% (94 runs sampled)
  minimatch x 1,031,198 ops/sec ±6.30% (96 runs sampled))

# .makeRe star; dot=true
  micromatch v4 x 2,038,269 ops/sec ±0.60% (91 runs sampled)
  micromatch v3 x 2,774,903 ops/sec ±0.67% (91 runs sampled)
  minimatch x 969,031 ops/sec ±0.69% (95 runs sampled)d)

# .makeRe globstar
  micromatch v4 x 1,876,114 ops/sec ±0.65% (95 runs sampled)
  micromatch v3 x 8,549,334 ops/sec ±0.62% (95 runs sampled)
  minimatch x 1,525,943 ops/sec ±0.70% (92 runs sampled)

# .makeRe globstars
  micromatch v4 x 1,848,299 ops/sec ±0.83% (92 runs sampled)
  micromatch v3 x 5,107,054 ops/sec ±0.57% (92 runs sampled)
  minimatch x 977,871 ops/sec ±0.62% (94 runs sampled)d)

# .makeRe with leading star
  micromatch v4 x 1,714,098 ops/sec ±0.69% (96 runs sampled)
  micromatch v3 x 8,341,519 ops/sec ±0.57% (93 runs sampled)
  minimatch x 787,529 ops/sec ±0.59% (94 runs sampled)

# .makeRe - braces
  micromatch v4 x 215,415 ops/sec ±4.66% (79 runs sampled))
  micromatch v3 x 4,920,938 ops/sec ±0.72% (83 runs sampled)
  minimatch x 104,371 ops/sec ±0.71% (90 runs sampled)

# .makeRe braces - range (expanded)
  micromatch v4 x 32,408 ops/sec ±0.90% (90 runs sampled)
  micromatch v3 x 2,333,566 ops/sec ±0.77% (91 runs sampled)
  minimatch x 3,071 ops/sec ±0.98% (93 runs sampled)

# .makeRe braces - range (compiled)
  micromatch v4 x 173,476 ops/sec ±1.69% (84 runs sampled)
  micromatch v3 x 4,609,440 ops/sec ±0.71% (84 runs sampled)
  minimatch x 866 ops/sec ±0.83% (92 runs sampled)

# .makeRe braces - nested ranges (expanded)
  micromatch v4 x 21,154 ops/sec ±0.77% (92 runs sampled)
  micromatch v3 x 1,966,487 ops/sec ±0.63% (93 runs sampled)
  minimatch x 2,991 ops/sec ±0.83% (91 runs sampled)

# .makeRe braces - nested ranges (compiled)
  micromatch v4 x 133,370 ops/sec ±1.65% (83 runs sampled)
  micromatch v3 x 4,135,701 ops/sec ±0.63% (89 runs sampled)
  minimatch x 867 ops/sec ±0.89% (89 runs sampled)

# .makeRe braces - set (compiled)
  micromatch v4 x 165,326 ops/sec ±1.56% (68 runs sampled)
  micromatch v3 x 4,153,965 ops/sec ±0.69% (85 runs sampled)
  minimatch x 37,657 ops/sec ±0.71% (92 runs sampled)

# .makeRe braces - nested sets (compiled)
  micromatch v4 x 117,424 ops/sec ±2.12% (64 runs sampled)
  micromatch v3 x 4,090,641 ops/sec ±1.29% (80 runs sampled)
  minimatch x 23,989 ops/sec ±0.72% (93 runs sampled)
```

Micromatch v3 is significantly faster it seems than micromatch v4.

I will try to see if I can find any obvious optimiziations, but opened this PR draft as a place to collect ideas around this topic.