### PR TITLE
ignore the order of negation patterns

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,6 @@ const micromatch = (list, patterns, options) => {
       if (negated) {
         omit.add(matched.output);
       } else {
-        omit.delete(matched.output);
         keep.add(matched.output);
       }
     }

--- a/test/negation.js
+++ b/test/negation.js
@@ -25,7 +25,7 @@ describe('negation', () => {
       assert.deepEqual(mm(fixtures1, ['*/*', '!a/b', '!*/c']), ['a/a', 'b/a', 'b/b']);
       assert.deepEqual(mm(fixtures1, ['*/*', '!a/b', '!a/c']), ['a/a', 'b/a', 'b/b', 'b/c']);
       assert.deepEqual(mm(fixtures1, ['!a/(b)']), ['a/a', 'a/c', 'b/a', 'b/b', 'b/c']);
-      assert.deepEqual(mm(['bar', 'baz', 'foo'], ['!bar', '*']), ['bar', 'baz', 'foo']);
+      assert.deepEqual(mm(['bar', 'baz', 'foo'], ['!bar', '*']), ['baz', 'foo']);
       assert.deepEqual(mm(['bar', 'baz', 'foo'], ['*', '!bar']), ['baz', 'foo']);
 
       let fixtures2 = ['foo', 'bar', 'baz', 'main', 'other', 'foo/a/b/c', 'bar/a/b/d', 'baz/a/b/e', 'a/a/a', 'a/a/b', 'a/a/c', 'a/a/file'];
@@ -40,7 +40,7 @@ describe('negation', () => {
 
       // assert.deepEqual(mm(fixtures, ['!a/a', '!a']), []);
       assert.deepEqual(mm(['bar', 'baz', 'foo'], '!foo'), ['bar', 'baz']);
-      assert.deepEqual(mm(['bar', 'baz', 'foo'], ['!bar', 'bar']), ['bar']);
+      assert.deepEqual(mm(['bar', 'baz', 'foo'], ['!bar', 'bar']), []);
       assert.deepEqual(mm(['bar', 'baz', 'foo'], ['!foo', 'bar']), ['bar']);
       assert.deepEqual(mm(['bar', 'baz', 'foo'], ['!foo']), ['bar', 'baz']);
       assert.deepEqual(mm(['bar', 'baz', 'foo'], ['bar', '!foo', '!bar']), []);


### PR DESCRIPTION
It seems that mm 4 changed so that the order of pattern matters, which leads to errors in other libraries like jest

For example in jest now this does not work as expected (nothing ignored, the negation patterns are always "trumped" by the match pattern at the end):
```
collectCoverageFrom: [
    '!**/__mocks__/**',
    '!**/__tests__/**',
    'extension/**'
  ],
```


but this does work as expected:
```
collectCoverageFrom: [
    'extension/**',
    '!**/__mocks__/**',
    '!**/__tests__/**'
  ],
```

Now the question is, was/is this intentional? I couldn't see it anywhere mentioned in the changelog. I wonder because there are actual tests verifying this behavior.

This PR would change the behavior, so that the order is irrelevant.