### PR TITLE
fix typo in docs

### DIFF
--- a/.verb.md
+++ b/.verb.md
@@ -42,7 +42,7 @@ console.log(micromatch.isMatch('foo', ['b*', 'f*'])) //=> true
 
 * Support for multiple glob patterns (no need for wrappers like multimatch)
 * Wildcards (`**`, `*.js`)
-* Negation (`'!a/*.js'`, `'*!(b).js']`)
+* Negation (`'!a/*.js'`, `'*!(b).js'`)
 * [extglobs](#extglobs) (`+(x|y)`, `!(a|b)`)
 * [POSIX character classes](#posix-bracket-expressions) (`[[:alpha:][:digit:]]`)
 * [brace expansion][braces] (`foo/{1..5}.md`, `bar/{a,b,c}.js`)


### PR DESCRIPTION
## Description

Remove erroneous square bracket from Matching features -> Negation section in docs.


## Checklist


### Fixing typos

- [X] Please review the [readme advice]() section before submitting changes

### Documentation

- [X] Please review the [readme advice](#readme-advice) section before submitting changes
