### PR TITLE
fix parse method's jsdoc

### DIFF
--- a/index.js
+++ b/index.js
@@ -408,7 +408,7 @@ micromatch.scan = (...args) => picomatch.scan(...args);
  *
  * ```js
  * const mm = require('micromatch');
- * const state = mm(pattern[, options]);
+ * const state = mm.parse(pattern[, options]);
  * ```
  * @param {String} `glob`
  * @param {Object} `options`


### PR DESCRIPTION
## Description

Fixes an error in the example given for the .parse method.

## Checklist

### Documentation

- [X] Please review the [readme advice](#readme-advice) section before submitting changes

