### PR TITLE
~100x perf improvement of `micromatch.not` on large inputs by using `Set.prototype.has` over `Array.prototype.includes`

### DIFF
--- a/index.js
+++ b/index.js
@@ -155,10 +155,10 @@ micromatch.not = (list, patterns, options = {}) => {
     items.push(state.output);
   };
 
-  let matches = micromatch(list, patterns, { ...options, onResult });
+  let matches = new Set(micromatch(list, patterns, { ...options, onResult }));
 
   for (let item of items) {
-    if (!matches.includes(item)) {
+    if (!matches.has(item)) {
       result.add(item);
     }
   }


### PR DESCRIPTION
# Motivation for this change

I use the `micromatch` library to support processing include/exclude glob patterns for file search in the [GitHub Repositories extension for VS Code](https://marketplace.visualstudio.com/items?itemName=GitHub.remotehub), which integrates with `github.dev` to allow users to browse repos without cloning them locally. I recently received a report that file search in a github.dev repo was not working for a user, tracked as https://github.com/microsoft/vscode-remote-repositories-github/issues/156. It turned out that it _was_ working, but was just taking a very long time.

By adding some timestamped log statements to the `micromatch` library code, I isolated the bottleneck to this block of code in the `micromatch.not` function:
https://github.com/micromatch/micromatch/blob/34f44b4f57eacbdbcc74f64252e0845cf44bbdbd/index.js#L160-L164

In my case, `items` contained 5mil elements, and `matches` contained 42k elements. This resulted in the library spending almost **9 minutes** in `micromatch.not`. 99.2% of that time was spent in the block of code above.

Here's an example of the logging I added in `micromatch.not`:
```ts
const postProcess = Date.now();
console.log(`[ MICROMATCH.NOT] Got ${matches.length} matches and ${items.length} items, postprocessing...`);

for (let item of items) {
  if (!matches.includes(item)) {
    result.add(item);
  }
}
console.log(` [ MICROMATCH.NOT] Done postprocessing in ${Date.now() - postProcess} ms, got ${result.size} results`);
```
And here are the numbers when run on the inputs mentioned above:
```
[ MICROMATCH] Done processing 42478 matches
[ MICROMATCH.NOT] Got 42478 matches and 5453280 items, postprocessing...
 [ MICROMATCH.NOT] Done postprocessing in 522035 ms, got 54902 results
[ GLOBFILTER] Done processing micromatch in 525728ms
```

# Impact of this change

With the change in this PR, this cuts the postprocessing time on my machine from 525728ms to 924ms, yielding an approximately 500x speedup in the postprocessing step. Overall, the time spent in the `micromatch.not` function goes from 525728ms to 4687ms, which is approximately a 100x improvement for consumers of the `micromatch.not` function:

```js
  let matches = new Set(micromatch(list, patterns, { ...options, onResult }));

  for (let item of items) {
    if (!matches.has(item)) {
      result.add(item);
    }
  }
```

```
[ MICROMATCH] Done processing 42478 matches
[ MICROMATCH.NOT] Got 42478 matches and 5453280 items, postprocessing...
 [ MICROMATCH.NOT] Done postprocessing in 924 ms, got 54902 results
[ GLOBFILTER] Done processing micromatch.not in 4687ms
```