### PR TITLE
chore!: bump picomatch@4.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "braces": "^3.0.2",
-    "picomatch": "^2.3.1"
+    "picomatch": "^4.0.1"
   },
   "devDependencies": {
     "fill-range": "^7.0.1",


### PR DESCRIPTION
List of changes can be found here: https://github.com/micromatch/picomatch/compare/2.3.1...6ce95f5e008590510adac57d1910e574aa65845f

The most notable is that picomatch now requires [Node.js >=12](https://github.com/micromatch/picomatch/commit/6ce95f5e008590510adac57d1910e574aa65845f)