### PR TITLE
Prepare version 4.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "micromatch",
   "description": "Glob matching for javascript/node.js. A replacement and faster alternative to minimatch and multimatch.",
-  "version": "4.0.6",
+  "version": "4.0.8",
   "homepage": "https://github.com/micromatch/micromatch",
   "author": "Jon Schlinkert (https://github.com/jonschlinkert)",
   "contributors": [
@@ -26,9 +26,7 @@
     "url": "https://github.com/micromatch/micromatch/issues"
   },
   "license": "MIT",
-  "files": [
-    "index.js"
-  ],
+  "files": ["index.js"],
   "main": "index.js",
   "engines": {
     "node": ">=8.6"
@@ -38,7 +36,7 @@
   },
   "dependencies": {
     "braces": "^3.0.3",
-    "picomatch": "^4.0.2"
+    "picomatch": "^2.3.1"
   },
   "devDependencies": {
     "fill-range": "^7.0.1",
@@ -90,30 +88,14 @@
   "verb": {
     "toc": "collapsible",
     "layout": "default",
-    "tasks": [
-      "readme"
-    ],
-    "plugins": [
-      "gulp-format-md"
-    ],
+    "tasks": ["readme"],
+    "plugins": ["gulp-format-md"],
     "lint": {
       "reflinks": true
     },
     "related": {
-      "list": [
-        "braces",
-        "expand-brackets",
-        "extglob",
-        "fill-range",
-        "nanomatch"
-      ]
+      "list": ["braces", "expand-brackets", "extglob", "fill-range", "nanomatch"]
     },
-    "reflinks": [
-      "extglob",
-      "fill-range",
-      "glob-object",
-      "minimatch",
-      "multimatch"
-    ]
+    "reflinks": ["extglob", "fill-range", "glob-object", "minimatch", "multimatch"]
   }
 }


### PR DESCRIPTION
Merged tag 4.0.7 into master, changed version to 4.0.8 so that 4.0.8 contains the code of 4.0.7 as well as the fixes for #264