### PR TITLE
Update Node.js versions in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [10, 12, 14, 16, 17]
+        node-version: [10, 12, 14, 16, 18, 20, 22]
         exclude:
           - os: macos-latest
             node-version: 10

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
             node-version: 14
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}


### PR DESCRIPTION
Adds current Node versions (18, 20, & 22), which were not part of test matrix. Also removes non-LTS version 17.

The checkout action itself used quite an old version, so I updated it to latest too. The previous version triggered deprecation warnings in Actions.